### PR TITLE
Feature/rag : Rag 변경 사항 수정

### DIFF
--- a/vector_db/retriever.py
+++ b/vector_db/retriever.py
@@ -1,36 +1,56 @@
-import numpy as np
+import torch
 from vector_db.utils import embed_texts
 from vector_db.chroma_client import collection
+from typing import List, Dict
+import logging
 
-if __name__ != "__main__":
-    import os
-    from vector_db.init_data import init_vector_store_from_csv
+def cosine_similarity_gpu(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    """정규화된 텐서들 간의 코사인 유사도 계산 (1:N)"""
+    a = a / torch.norm(a, dim=-1, keepdim=True)
+    b = b / torch.norm(b, dim=-1, keepdim=True)
+    return torch.matmul(a, b.T)  
 
-    current_dir = os.path.dirname(__file__)
-    csv_path = os.path.join(current_dir, "question_data.csv")
-    init_vector_store_from_csv(csv_path)
+def rag_retriever(
+    main_question: str,
+    keyword: str,
+    top_k: int = 6,
+    sim_threshold: float = 0.6
+) -> List[Dict[str, float]]:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-def cosine_similarity(a, b):
-    a = np.array(a)
-    b = np.array(b)
-    return np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b))
+    try:
+        keyword_emb = embed_texts([keyword])[0] 
+        keyword_tensor = torch.tensor(keyword_emb, dtype=torch.float32, device=device).unsqueeze(0)
 
-def rag_retriever(main_question: str, keyword: str, top_k: int = 6, sim_threshold: float = 0.6):
-    keyword_embedding = embed_texts([keyword])[0]
-    results = collection.query(
-        query_embeddings=[keyword_embedding],
-        n_results=top_k * 2,
-        include=["documents", "embeddings"]
-    )
+        results = collection.query(
+            query_embeddings=[keyword_emb],  
+            n_results=top_k * 5, 
+            include=["documents", "embeddings"]
+        )
 
-    all_questions = results["documents"][0]
-    all_embeddings = results["embeddings"][0]
+        docs = results.get("documents", [[]])[0]
+        embs = results.get("embeddings", [[]])[0]
 
-    filtered = []
-    for q, q_emb in zip(all_questions, all_embeddings):
-        sim = cosine_similarity(keyword_embedding, q_emb)
-        if sim >= sim_threshold:
-            filtered.append({"question": q, "similarity": round(sim, 4)})
+        if len(docs) == 0 or len(embs) == 0:
+            return []
 
-    filtered.sort(key=lambda x: -x["similarity"])
-    return filtered[:top_k]
+        embedding_tensor = torch.tensor(embs, dtype=torch.float32, device=device)
+
+        similarities = cosine_similarity_gpu(keyword_tensor, embedding_tensor).squeeze(0)
+
+        top_sim_values, top_indices = similarities.topk(k=top_k * 2)
+
+        filtered = [
+            {
+                "question": docs[i],
+                "similarity": round(sim, 4)
+            }
+            for i, sim in zip(top_indices.tolist(), top_sim_values.tolist())
+            if sim >= sim_threshold
+        ]
+
+        return filtered[:top_k]
+
+    except Exception as e:
+        logging.warning(f"RAG 검색 실패: {e}")
+        return []

--- a/vector_db/retriever.py
+++ b/vector_db/retriever.py
@@ -5,7 +5,6 @@ from typing import List, Dict
 import logging
 
 def cosine_similarity_gpu(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
-    """정규화된 텐서들 간의 코사인 유사도 계산 (1:N)"""
     a = a / torch.norm(a, dim=-1, keepdim=True)
     b = b / torch.norm(b, dim=-1, keepdim=True)
     return torch.matmul(a, b.T)  


### PR DESCRIPTION
### Description

`retriever.py` 내부에서 사용하는 `embed_texts()` 함수가 내부적으로 `SentenceTransformer` 모델을 로딩하고 사용하고 있기 때문에, FastAPI 서버 시작 시 모델을 미리 로딩하여 최초 요청 시 지연을 방지하도록 구조를 개선했습니다.

---

### Changes Made

1. `retriever.py`는 직접적으로 모델을 호출하진 않지만, `embed_texts()` 내부에서 모델이 사용되므로 간접적으로 영향을 받음

---

### Testing

1. `uvicorn vector_db.main:app --reload`로 서버 실행
2. 시작 로그에 `모델 로딩 완료` 메시지 확인
3. `/search` API 요청 시 최초 요청의 임베딩 로딩 지연 없이 즉시 응답되는지 확인

---

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 테스트를 통해 모델이 중복 로딩되지 않는 것을 확인했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.

---

### Additional Notes

- `retriever.py`에서 직접 `get_model()`이나 `model.encode()`를 호출하진 않지만, `utils.embed_texts()`를 통해 간접적으로 임베딩 모델을 사용하는 구조입니다.
- 이 구조는 서비스 초기 구동 시 모델을 한 번만 로딩하고 이후 모든 임베딩 요청에서 재사용할 수 있도록 최적화된 형태입니다.
