### PR TITLE
Embedding model 1번만 로딩

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, Request
 from app.api import router  # __init__.py에서 통합된 router
 from app.api.question_generator.question_generator_model import initialize_llm
 # from vector_db.init_data import init_vector_store_from_csv
+from vector_db.utils import get_model
 import logging
 
 app = FastAPI()
@@ -11,3 +12,4 @@ app.include_router(router)
 @app.on_event("startup")
 async def startup_event():
     initialize_llm()
+    get_model()


### PR DESCRIPTION
### Description

`retriever.py` 내부에서 사용하는 `embed_texts()` 함수가 내부적으로 `SentenceTransformer` 모델을 로딩하고 사용하고 있기 때문에, FastAPI 서버 시작 시 모델을 미리 로딩하여 최초 요청 시 지연을 방지하도록 구조를 개선했습니다.

---

### Related Issues

- Resolves #[이슈 번호]

---

### Changes Made

1. `main.py`에 `@app.on_event("startup")` 이벤트 추가
2. 서버 시작 시 `get_model()`을 선 호출하여 SentenceTransformer 모델을 미리 로딩
3. `retriever.py`는 직접적으로 모델을 호출하진 않지만, `embed_texts()` 내부에서 모델이 사용되므로 간접적으로 영향을 받음

---

### Testing

1. `uvicorn vector_db.main:app --reload`로 서버 실행
2. 시작 로그에 `모델 로딩 완료` 메시지 확인
3. `/search` API 요청 시 최초 요청의 임베딩 로딩 지연 없이 즉시 응답되는지 확인

---

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 테스트를 통해 모델이 중복 로딩되지 않는 것을 확인했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.

---

### Additional Notes

- `retriever.py`에서 직접 `get_model()`이나 `model.encode()`를 호출하진 않지만, `utils.embed_texts()`를 통해 간접적으로 임베딩 모델을 사용하는 구조입니다.
- 이 구조는 서비스 초기 구동 시 모델을 한 번만 로딩하고 이후 모든 임베딩 요청에서 재사용할 수 있도록 최적화된 형태입니다.
